### PR TITLE
Remove time-check for redeem

### DIFF
--- a/contracts/partials/wxtz/tzip-7/bridge/helpers/validators.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/helpers/validators.religo
@@ -15,14 +15,6 @@ let isValidSwapTime = (swap: swap): bool => {
     swap.releaseTime >= Tezos.now;
 };
 
-let failIfSwapIsOver = (swap: swap): unit => {
-    let isValidSwapTime = isValidSwapTime(swap);
-    switch(isValidSwapTime) {
-        | true => unit
-        | false => (failwith(errorSwapIsOver): unit)
-    };
-};
-
 let failIfSwapIsNotOver = (swap: swap): unit => {
     let isValidSwapTime = isValidSwapTime(swap);
     switch(isValidSwapTime) {

--- a/contracts/partials/wxtz/tzip-7/bridge/redeem/redeem.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/redeem/redeem.religo
@@ -12,8 +12,6 @@ let redeem = ((redeemParameter, storage): (redeemParameter, storage)): entrypoin
     failIfSwapIsNotConfirmed(secretHash, storage.bridge.swaps);
     // use the calculated hash to retrieve swap record from bridge storage
     let swap = getSwapLock(secretHash, storage.bridge.swaps);
-    // check whether swap time period has expired
-    failIfSwapIsOver(swap);
 
     // construct the transfer parameter to redeem locked-up tokens
     let totalValue = swap.value + swap.fee;

--- a/contracts/partials/wxtz/tzip-7/errors.religo
+++ b/contracts/partials/wxtz/tzip-7/errors.religo
@@ -11,7 +11,6 @@ let errorSwapLockDoesNotExist: string = "SwapLockDoesNotExist";
 let errorFundsLock: string = "FundsLock";
 let errorSwapLockAlreadyExists: string = "SwapLockAlreadyExists";
 let errorTooLongSecret: string = "TooLongSecret";
-let errorSwapIsOver: string = "SwapIsOver";
 let errorSwapIsNotConfirmed: string = "SwapIsNotConfirmed";
 let errorSenderIsNotTheInitiator: string = "SenderIsNotTheInitiator";
 let errorSwapIsAlreadyConfirmed: string = "SwapIsAlreadyConfirmed";

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -22,7 +22,6 @@ module.exports = {
             senderIsNotTheInitiator: "SenderIsNotTheInitiator",
             swapIsAlreadyConfirmed: "SwapIsAlreadyConfirmed",
             swapIsNotConfirmed: "SwapIsNotConfirmed",
-            swapIsOver: "SwapIsOver",
             swapLockAlreadyExists: "SwapLockAlreadyExists",
             swapLockDoesNotExist: "SwapLockDoesNotExist",
             tokenOperationsPaused: "TokenOperationsArePaused",

--- a/test/unit/bridge/redeem.js
+++ b/test/unit/bridge/redeem.js
@@ -133,29 +133,4 @@ contract('TZIP-7 with bridge', () => {
                 .and.have.property('message', contractErrors.tzip7.swapIsNotConfirmed);
         });
     });
-
-    describe('Invoke %redeem on bridge for a confirmed swap when release time is passed', () => {
-
-        beforeEach(async () => {
-            await before(
-                _tzip7InitialStorage.withApprovals,
-                accounts,
-                helpers,
-            );
-            // locking through contract call is leaner than migrating swap
-            await _taquitoHelpers.setSigner(accounts.sender.sk);
-            swapSecret = _cryptoHelpers.randomSecret();
-            swapLockParameters.secretHash = _cryptoHelpers.hash(swapSecret);
-            swapLockParameters.confirmed = true;
-            swapLockParameters.releaseTime = getDelayedISOTime(-1); // 1h in the past
-            await helpers.tzip7.lock(swapLockParameters);
-        });
-
-        it('should fail for swap past release time', async () => {
-            const operationPromise = helpers.tzip7.redeem(swapSecret);
-            await expect(operationPromise).to.be.eventually.rejected
-                .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.swapIsOver);
-        });
-    });
 });


### PR DESCRIPTION
Following a specification update, this change was required to align the Tezos implementation with the Ethereum swap contract.