### PR TITLE
Change key in swaps big_map

### DIFF
--- a/contracts/partials/wxtz/getViews/parameter.religo
+++ b/contracts/partials/wxtz/getViews/parameter.religo
@@ -18,7 +18,7 @@ type requestTotalSupplyParameter = contractAddress;
 
 type requestSwapParameter = {
     at: contractAddress,
-    request: secretHash,
+    request: getSwapRequest,
 };
 
 type parameter = 

--- a/contracts/partials/wxtz/getViews/requestSwap.religo
+++ b/contracts/partials/wxtz/getViews/requestSwap.religo
@@ -10,7 +10,8 @@ let requestSwap = ((requestSwapParameter, storage): (requestSwapParameter, stora
         | None => (failwith(errorNoContract): contract(getSwapResponse))
     };
     let request: getSwapParameter = {
-        secretHash: requestSwapParameter.request,
+        secretHash: requestSwapParameter.request.secretHash,
+        swapInitiator: requestSwapParameter.request.swapInitiator,
         callback: callbackEntrypoint,
     };
     let operation = Tezos.transaction(

--- a/contracts/partials/wxtz/getViews/types.religo
+++ b/contracts/partials/wxtz/getViews/types.religo
@@ -13,6 +13,11 @@ type getAllowanceRequest = {
     spender: address,
 };
 
+type getSwapRequest = {
+    secretHash: secretHash,
+    swapInitiator: address,
+};
+
 type response = 
 | GetBalanceResponse(getBalanceResponse)
 | GetAllowanceResponse(getAllowanceResponse)

--- a/contracts/partials/wxtz/tzip-7/bridge/claimRefund/claimRefund.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/claimRefund/claimRefund.religo
@@ -4,11 +4,14 @@
 let claimRefund = ((claimRefundParameter, storage): (claimRefundParameter, storage)): entrypointReturn => {
 	// continue only if token operations are not paused
 	failIfPaused(storage.token);   
+
+    let swapInitiator = Tezos.sender;
+    let swapId: swapId = (claimRefundParameter.secretHash, swapInitiator);
     // check that sender of transaction has permission to confirm the swap
-    failIfSenderIsNotTheInitiator(claimRefundParameter.secretHash, storage.bridge.swaps);
+    failIfSenderIsNotTheInitiator(swapId, storage.bridge.swaps);
     
     // retrieve swap record from storage
-    let swap = getSwapLock(claimRefundParameter.secretHash, storage.bridge.swaps);
+    let swap = getSwapLock(swapId, storage.bridge.swaps);
 	// check for swap protocol time condition
     failIfSwapIsNotOver(swap);
 
@@ -31,7 +34,7 @@ let claimRefund = ((claimRefundParameter, storage): (claimRefundParameter, stora
     let tokenStorage = updateLedgerByTransfer(transferFeeParameter, tokenStorage);
     
     // remove the swap record from storage
-    let bridgeStorage = removeSwapLock(claimRefundParameter.secretHash, storage.bridge);
+    let bridgeStorage = removeSwapLock(swapId, storage.bridge);
 
     // update both token ledger storage and swap records in bridge storage
     let storage = {

--- a/contracts/partials/wxtz/tzip-7/bridge/confirmSwap/confirmSwap.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/confirmSwap/confirmSwap.religo
@@ -3,12 +3,14 @@
 let confirmSwap = ((confirmSwapParameter, bridgeStorage): (confirmSwapParameter, bridgeStorage)): bridgeEntrypointReturn => {
     // confirm swap transaction ignores paused token operations
     
+    let swapInitiator = Tezos.sender;
+    let swapId: swapId = (confirmSwapParameter.secretHash, swapInitiator);
     // check that sender of transaction has permission to confirm the swap
-    failIfSenderIsNotTheInitiator(confirmSwapParameter.secretHash, bridgeStorage.swaps);
+    failIfSenderIsNotTheInitiator(swapId, bridgeStorage.swaps);
     // check if swap was already confirmed
-    failIfSwapIsAlreadyConfirmed(confirmSwapParameter.secretHash, bridgeStorage.swaps);
+    failIfSwapIsAlreadyConfirmed(swapId, bridgeStorage.swaps);
     // retrieve swap record from storage
-    let swap = getSwapLock(confirmSwapParameter.secretHash, bridgeStorage.swaps);
+    let swap = getSwapLock(swapId, bridgeStorage.swaps);
 
     // change confirmed value to true in swap record
     let swap = {
@@ -17,7 +19,7 @@ let confirmSwap = ((confirmSwapParameter, bridgeStorage): (confirmSwapParameter,
     };
     // update swap record in bridge storage
     let swaps = updateSwapLock(
-        confirmSwapParameter.secretHash,
+        swapId,
         swap,
         bridgeStorage.swaps
     );

--- a/contracts/partials/wxtz/tzip-7/bridge/getSwap/getSwap.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/getSwap/getSwap.religo
@@ -1,6 +1,7 @@
 let getSwap = ((getSwapParameter, bridgeStorage): (getSwapParameter, bridgeStorage)): bridgeEntrypointReturn => {
     // retrieve swap record from bridge storage
-    let swap = getSwapLock(getSwapParameter.secretHash, bridgeStorage.swaps);
+    let swapId: swapId = (getSwapParameter.secretHash, getSwapParameter.swapInitiator);
+    let swap = getSwapLock(swapId, bridgeStorage.swaps);
 
     let operation = Tezos.transaction(
         swap,

--- a/contracts/partials/wxtz/tzip-7/bridge/getSwap/parameter.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/getSwap/parameter.religo
@@ -1,6 +1,7 @@
 type getSwapParameter = 
 [@layout:comb]
-{
+{   
     secretHash: secretHash,
+    swapInitiator: address,
     callback: contract(swap),
 };

--- a/contracts/partials/wxtz/tzip-7/bridge/helpers/permissions.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/helpers/permissions.religo
@@ -4,8 +4,8 @@ let isSenderInitiator = (swap: swap): bool => {
     Tezos.sender == swap.from_;
 };
 
-let failIfSenderIsNotTheInitiator = ((secretHash, swaps): (secretHash, swaps)): unit => {
-    let swap = getSwapLock(secretHash, swaps);
+let failIfSenderIsNotTheInitiator = ((swapId, swaps): (swapId, swaps)): unit => {
+    let swap = getSwapLock(swapId, swaps);
     // check that sender of the transaction has permission
     let isSenderInitiator = isSenderInitiator(swap);
     switch (isSenderInitiator) {
@@ -18,8 +18,8 @@ let isSwapConfirmed = (swap: swap): bool => {
     swap.confirmed == true;
 };
 
-let failIfSwapIsNotConfirmed = ((secretHash, swaps): (secretHash, swaps)): unit => {
-    let swap = getSwapLock(secretHash, swaps);
+let failIfSwapIsNotConfirmed = ((swapId, swaps): (swapId, swaps)): unit => {
+    let swap = getSwapLock(swapId, swaps);
     let isSwapConfirmed = isSwapConfirmed(swap);
     switch (isSwapConfirmed) {
         | true => unit
@@ -27,8 +27,8 @@ let failIfSwapIsNotConfirmed = ((secretHash, swaps): (secretHash, swaps)): unit 
     };
 };
 
-let failIfSwapIsAlreadyConfirmed = ((secretHash, swaps): (secretHash, swaps)): unit => {
-    let swap = getSwapLock(secretHash, swaps);
+let failIfSwapIsAlreadyConfirmed = ((swapId, swaps): (swapId, swaps)): unit => {
+    let swap = getSwapLock(swapId, swaps);
     let isSwapConfirmed = isSwapConfirmed(swap);
     switch (isSwapConfirmed) {
         | true => (failwith(errorSwapIsAlreadyConfirmed): unit)

--- a/contracts/partials/wxtz/tzip-7/bridge/helpers/permissions.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/helpers/permissions.religo
@@ -1,16 +1,13 @@
 #include "../../storage/swapLockRepository.religo"
 
-let isSenderInitiator = (swap: swap): bool => {
-    Tezos.sender == swap.from_;
-};
-
+/**
+ * This is basically getSwapLock() with a different error message.
+ */
 let failIfSenderIsNotTheInitiator = ((swapId, swaps): (swapId, swaps)): unit => {
-    let swap = getSwapLock(swapId, swaps);
-    // check that sender of the transaction has permission
-    let isSenderInitiator = isSenderInitiator(swap);
-    switch (isSenderInitiator) {
-        | true => unit
-        | false => (failwith(errorSenderIsNotTheInitiator): unit)
+    let swap = Big_map.find_opt(swapId, swaps);
+    switch (swap) {
+        | Some(swap) => unit
+        | None => (failwith(errorSenderIsNotTheInitiator): unit)
     };
 };
 

--- a/contracts/partials/wxtz/tzip-7/bridge/redeem/parameter.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/redeem/parameter.religo
@@ -1,3 +1,4 @@
 type redeemParameter = {
     secret: secret,
+    swapInitiator: address,
 };

--- a/contracts/partials/wxtz/tzip-7/bridge/redeem/redeem.religo
+++ b/contracts/partials/wxtz/tzip-7/bridge/redeem/redeem.religo
@@ -6,9 +6,10 @@ let redeem = ((redeemParameter, storage): (redeemParameter, storage)): entrypoin
     // calculate SHA-256 hash of provided secret
     let secretHash = Crypto.sha256(redeemParameter.secret);
     // continue only if swap was confirmed
-    failIfSwapIsNotConfirmed(secretHash, storage.bridge.swaps);
-    // use the calculated hash to retrieve swap record from bridge storage
-    let swap = getSwapLock(secretHash, storage.bridge.swaps);
+    let swapId: swapId = (secretHash, redeemParameter.swapInitiator);
+    failIfSwapIsNotConfirmed(swapId, storage.bridge.swaps);
+    // use the calculated hash to retrieve swap record from bridge storage with the swapId
+    let swap = getSwapLock(swapId, storage.bridge.swaps);
 
     // construct the transfer parameter to redeem locked-up tokens
     let totalValue = swap.value + swap.fee;
@@ -21,7 +22,7 @@ let redeem = ((redeemParameter, storage): (redeemParameter, storage)): entrypoin
     let tokenStorage = updateLedgerByTransfer(transferParameter, storage.token);
 
     // remove swap record from bridge storage
-    let bridgeStorage = removeSwapLock(secretHash, storage.bridge);
+    let bridgeStorage = removeSwapLock(swapId, storage.bridge);
     // save secret and secretHash as outcome in bridge storage
     let bridgeStorage = setOutcome(secretHash, redeemParameter.secret, bridgeStorage);
 

--- a/contracts/partials/wxtz/tzip-7/storage/swapLockRepository.religo
+++ b/contracts/partials/wxtz/tzip-7/storage/swapLockRepository.religo
@@ -1,37 +1,37 @@
 #include "../errors.religo"
 
-let getSwapLock = ((secretHash, swaps): (secretHash, swaps)): swap => {
-    let swap = Big_map.find_opt(secretHash, swaps);
+let getSwapLock = ((swapId, swaps): (swapId, swaps)): swap => {
+    let swap = Big_map.find_opt(swapId, swaps);
 	switch (swap) {
 		| Some(swap) => swap
 		| None => (failwith(errorSwapLockDoesNotExist): swap)
 	};
 };
 
-let setSwapLock = ((secretHash, swap, swaps): (secretHash, swap, swaps)): swaps => {
+let setSwapLock = ((swapId, swap, swaps): (swapId, swap, swaps)): swaps => {
 	Big_map.add(
-		secretHash,
+		swapId,
 		swap,
 		swaps
 	);
 };
 
 // the logic is different to getSwapLock
-let failIfSwapLockExists = ((secretHash, swaps): (secretHash, swaps)): unit => {
-	let existingSwap = Big_map.find_opt(secretHash, swaps);
+let failIfSwapLockExists = ((swapId, swaps): (swapId, swaps)): unit => {
+	let existingSwap = Big_map.find_opt(swapId, swaps);
 	switch(existingSwap) {
 		| Some(swap) => (failwith(errorSwapLockAlreadyExists): unit)
 		| None => unit
 	};
 };
 
-let setNewSwapLock = ((secretHash, swap, swaps): (secretHash, swap, swaps)): swaps => {
-	failIfSwapLockExists(secretHash, swaps);
-	setSwapLock(secretHash, swap, swaps);
+let setNewSwapLock = ((swapId, swap, swaps): (swapId, swap, swaps)): swaps => {
+	failIfSwapLockExists(swapId, swaps);
+	setSwapLock(swapId, swap, swaps);
 };
 
-let removeSwapLock = ((secretHash, bridgeStorage): (secretHash, bridgeStorage)): bridgeStorage => {
-	let swaps = Big_map.remove(secretHash, bridgeStorage.swaps);
+let removeSwapLock = ((swapId, bridgeStorage): (swapId, bridgeStorage)): bridgeStorage => {
+	let swaps = Big_map.remove(swapId, bridgeStorage.swaps);
     let bridgeStorage = {
         ...bridgeStorage,
         swaps: swaps,
@@ -39,9 +39,9 @@ let removeSwapLock = ((secretHash, bridgeStorage): (secretHash, bridgeStorage)):
     bridgeStorage;
 };
 
-let updateSwapLock = ((secretHash, swap, swaps): (secretHash, swap, swaps)): swaps => {
+let updateSwapLock = ((swapId, swap, swaps): (swapId, swap, swaps)): swaps => {
     Big_map.update(
-        secretHash,
+        swapId,
         Some(swap),
         swaps
     );

--- a/contracts/partials/wxtz/tzip-7/storage/types.religo
+++ b/contracts/partials/wxtz/tzip-7/storage/types.religo
@@ -8,7 +8,8 @@ type swap = {
     [@annot:to] to_: address,
     value: nat,
 };
-type swaps = big_map(secretHash, swap);
+type swapId = (secretHash, address);
+type swaps = big_map(swapId, swap);
 type outcomes = big_map(secretHash, secret);
 
 type ledger = big_map(address, nat);

--- a/migrations/initialStorage/tzip-7.js
+++ b/migrations/initialStorage/tzip-7.js
@@ -97,25 +97,6 @@ initialStorage.test.lock = () => {
         value: 5000
     })
     return storage;
-    // bridge: {
-    //     ...initialStorage.withApprovals.bridge,
-    //     swaps: (() => {
-    //         const map = new MichelsonMap;
-    //         map.set({
-    //             0: 'b7c1fcab1eac98de7a021c73906e2c930cb46d9cf1c90aef6bd549f0ba00f25a', 
-    //             1: bob.pkh
-    //         }, {
-    //             confirmed: false,
-    //             fee: 100,
-    //             from: bob.pkh,
-    //             releaseTime: getDelayedISOTime(60),
-    //             to: carol.pkh,
-    //             value: 5000
-    //         });
-    //         return map;
-    //     })(),
-    //     outcomes: new MichelsonMap
-    // },
 };
 
 initialStorage.test.confirmSwap = (swapId, confirmed) => {

--- a/test/helpers/tzip-7.js
+++ b/test/helpers/tzip-7.js
@@ -114,8 +114,8 @@ const tzip7Helpers = (instance) => {
                 .send();
             return operation.confirmation(1);
         },
-        getSwap: async function(secretHash) {
-            const swap = await (await this.getStorage()).bridge.swaps.get(secretHash);
+        getSwap: async function(swapId) {
+            const swap = await (await this.getStorage()).bridge.swaps.get(swapId);
             if (swap != undefined) {
                 swap.fee = swap.fee.toNumber();
                 swap.value = swap.value.toNumber();
@@ -128,9 +128,9 @@ const tzip7Helpers = (instance) => {
                 .send();
             return operation.confirmation(1);
         },
-        redeem: async function(secret) {
+        redeem: async function(secret, swapInitiator) {
             const operation = await instance.methods
-                .redeem(secret)
+                .redeem(secret, swapInitiator)
                 .send();
             return operation.confirmation(1);
         },

--- a/test/unit/bridge/claimRefund.js
+++ b/test/unit/bridge/claimRefund.js
@@ -39,7 +39,6 @@ contract('TZIP-7 with bridge', () => {
             );            
         });
 
-
         it('should fail if token operations are paused', async () => {
             // call %setPause with pause guardian
             await _taquitoHelpers.signAs(accounts.pauseGuardian.sk, async () => {
@@ -53,21 +52,14 @@ contract('TZIP-7 with bridge', () => {
                 .and.have.property('message', contractErrors.tzip7.tokenOperationsPaused);
         });
 
+        // this is basically the same as a swap lock that does not exist
         it('should fail if sender is not initiator of the swap', async () => {
             await _taquitoHelpers.setSigner(accounts.thirdParty.sk);
             const operationPromise = helpers.tzip7.claimRefund(swapLockParameters.secretHash);            
 
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
-        });
-
-        it('should fail for a swap lock that does not exist', async () => {
-            const operationPromise = helpers.tzip7.claimRefund(_cryptoHelpers.randomHash());
-            
-            await expect(operationPromise).to.be.eventually.rejected
-                .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
+                .and.have.property('message', contractErrors.tzip7.senderIsNotTheInitiator);
         });
 
         describe('effects of invoking %claimRefund', () => {

--- a/test/unit/bridge/claimRefund.js
+++ b/test/unit/bridge/claimRefund.js
@@ -19,18 +19,24 @@ contract('TZIP-7 with bridge', () => {
         to: accounts.recipient.pkh,
         value: 5000
     };
+    let swapId;
 
     describe('Invoke %claimRefund on bridge for a swap lock past the release time', () => {
 
         beforeEach(async () => {
+            await _taquitoHelpers.setSigner(accounts.sender.sk);
+            const swapInitiator = accounts.sender.pkh;
             swapSecret = _cryptoHelpers.randomSecret();
             swapLockParameters.secretHash = _cryptoHelpers.hash(swapSecret);
+            swapId = {
+                0: swapLockParameters.secretHash,
+                1: swapInitiator
+            };
             await before(
-                _tzip7InitialStorage.test.claimRefund(swapLockParameters),
+                _tzip7InitialStorage.test.claimRefund(swapLockParameters, swapInitiator),
                 accounts,
                 helpers
-            );
-            await _taquitoHelpers.setSigner(accounts.sender.sk);
+            );            
         });
 
 
@@ -53,7 +59,7 @@ contract('TZIP-7 with bridge', () => {
 
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.senderIsNotTheInitiator);
+                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
         });
 
         it('should fail for a swap lock that does not exist', async () => {
@@ -88,7 +94,7 @@ contract('TZIP-7 with bridge', () => {
             
             it('should remove swap record in contract storage', async () => {
                 // swap record not found
-                const swap = await helpers.tzip7.getSwap(swapLockParameters.secretHash);
+                const swap = await helpers.tzip7.getSwap(swapId);
                 // TODO: find better way of catching this storage read error
                 expect(swap).to.be.undefined;
             });
@@ -104,7 +110,7 @@ contract('TZIP-7 with bridge', () => {
             await helpers.tzip7.claimRefund(swapLockParameters.secretHash);
             // switch to recipient and invoke %redeem
             await _taquitoHelpers.setSigner(accounts.recipient.sk);
-            const operationPromise = helpers.tzip7.redeem(swapLockParameters.secretHash);
+            const operationPromise = helpers.tzip7.redeem(swapLockParameters.secretHash, accounts.sender.pkh);
             
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
@@ -115,16 +121,17 @@ contract('TZIP-7 with bridge', () => {
     describe('Invoke %claimRefund on bridge for a swap lock before the release time', () => {
 
         beforeEach(async () => {
+            await _taquitoHelpers.setSigner(accounts.sender.sk);
+            const swapInitiator = accounts.sender.pkh;
             swapSecret = _cryptoHelpers.randomSecret();
             swapLockParameters.secretHash = _cryptoHelpers.hash(swapSecret);
             swapLockParameters.releaseTime = getDelayedISOTime(60); // time in the future, release time not reached
 
             await before(
-                _tzip7InitialStorage.test.claimRefund(swapLockParameters),
+                _tzip7InitialStorage.test.claimRefund(swapLockParameters, swapInitiator),
                 accounts,
                 helpers
             );
-            await _taquitoHelpers.setSigner(accounts.sender.sk);
         });
 
         it('should fail for a swap lock that did not reach release time', async () => {

--- a/test/unit/bridge/confirmSwap.js
+++ b/test/unit/bridge/confirmSwap.js
@@ -53,7 +53,7 @@ contract('TZIP-7 with bridge', () => {
             
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
+                .and.have.property('message', contractErrors.tzip7.senderIsNotTheInitiator);
         });
 
         it('should fail for a third party', async () => {
@@ -63,15 +63,7 @@ contract('TZIP-7 with bridge', () => {
             
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
-        });
-        
-        it('should fail for a non-existing swap', async () => {
-            const operationPromise = helpers.tzip7.confirmSwap(_cryptoHelpers.randomHash());
-
-            await expect(operationPromise).to.be.eventually.rejected
-                .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
+                .and.have.property('message', contractErrors.tzip7.senderIsNotTheInitiator);
         });
     });
 
@@ -92,8 +84,6 @@ contract('TZIP-7 with bridge', () => {
             tzip7Instance = await tzip7.new(initialstorage);
             // display the current contract address for debugging purposes
             console.log('Originated token contract at:', tzip7Instance.address);
-
- 
 
             helpers.tzip7 = await _tzip7Helpers.at(tzip7Instance.address);
         });

--- a/test/unit/bridge/confirmSwap.js
+++ b/test/unit/bridge/confirmSwap.js
@@ -12,20 +12,26 @@ const { TezosOperationError } = require('@taquito/taquito');
 contract('TZIP-7 with bridge', () => {
     let helpers = {};
     let secretHash;
+    let swapId;
 
     describe('Invoke %confirmSwap on bridge for an unconfirmed swap', () => {
 
         beforeEach(async () => {
+            await _taquitoHelpers.initialize();
+            await _taquitoHelpers.setSigner(accounts.sender.sk);    
             secretHash = _cryptoHelpers.randomHash();
+            const swapInitiator = accounts.sender.pkh;
+            // michelson pair
+            swapId = {
+                0: secretHash,
+                1: swapInitiator
+            }
             // deploy TZIP-7 instance with specific storage
-            const initialstorage = _tzip7InitialStorage.test.confirmSwap(secretHash, false); // unconfirmed
+            const initialstorage = _tzip7InitialStorage.test.confirmSwap(swapId, false); // unconfirmed
             tzip7Instance = await tzip7.new(initialstorage);
             // display the current contract address for debugging purposes
             console.log('Originated token contract at:', tzip7Instance.address);
-    
-            await _taquitoHelpers.initialize();
-            await _taquitoHelpers.setSigner(accounts.sender.sk);
-    
+
             helpers.tzip7 = await _tzip7Helpers.at(tzip7Instance.address);
         });
 
@@ -36,7 +42,7 @@ contract('TZIP-7 with bridge', () => {
 
         it('should change the swap property confirmed to true in storage', async () => {
             await helpers.tzip7.confirmSwap(secretHash);
-            const swap = await helpers.tzip7.getSwap(secretHash);
+            const swap = await helpers.tzip7.getSwap(swapId);
             expect(swap.confirmed).to.be.true;
         });
 
@@ -47,7 +53,7 @@ contract('TZIP-7 with bridge', () => {
             
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.senderIsNotTheInitiator);
+                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
         });
 
         it('should fail for a third party', async () => {
@@ -57,7 +63,7 @@ contract('TZIP-7 with bridge', () => {
             
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
-                .and.have.property('message', contractErrors.tzip7.senderIsNotTheInitiator);
+                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
         });
         
         it('should fail for a non-existing swap', async () => {
@@ -72,15 +78,22 @@ contract('TZIP-7 with bridge', () => {
     describe('Invoke %confirmSwap on bridge for a confirmed swap', () => {
 
         beforeEach(async () => {
+            await _taquitoHelpers.initialize();
+            await _taquitoHelpers.setSigner(accounts.sender.sk);
             secretHash = _cryptoHelpers.randomHash();
+            const swapInitiator = accounts.sender.pkh;
+            // michelson pair
+            swapId = {
+                0: secretHash,
+                1: swapInitiator
+            }
             // deploy TZIP-7 instance with specific storage
-            const initialstorage = _tzip7InitialStorage.test.confirmSwap(secretHash, true); // confirmed
+            const initialstorage = _tzip7InitialStorage.test.confirmSwap(swapId, true); // confirmed
             tzip7Instance = await tzip7.new(initialstorage);
             // display the current contract address for debugging purposes
             console.log('Originated token contract at:', tzip7Instance.address);
 
-            await _taquitoHelpers.initialize();
-            await _taquitoHelpers.setSigner(accounts.sender.sk);
+ 
 
             helpers.tzip7 = await _tzip7Helpers.at(tzip7Instance.address);
         });

--- a/test/unit/bridge/getSwap.js
+++ b/test/unit/bridge/getSwap.js
@@ -1,4 +1,3 @@
-
 const _cryptoHelpers = require('../../../helpers/crypto');
 const _tzip7InitialStorage = require('./../../../migrations/initialStorage/tzip-7');
 const _taquitoHelpers = require('../../helpers/taquito');
@@ -6,6 +5,8 @@ const getViews = artifacts.require('getViews');
 const accounts = require('./accounts');
 const getDelayedISOTime = require('../../../helpers/getDelayedISOTime');
 const { expect } = require('chai').use(require('chai-as-promised'));
+const { contractErrors } = require('./../../../helpers/constants');
+const { TezosOperationError } = require('@taquito/taquito');
 const before = require('./before');
 
 contract('TZIP-7 with bridge', () => {
@@ -55,6 +56,19 @@ contract('TZIP-7 with bridge', () => {
             swapRecord.from = accounts.sender.pkh; // add this for assertion
             delete swapRecord.secretHash; // remove this for assertion
             expect(swapFromContract).to.include(swapRecord);
+        });
+
+        it('should fail for a non-existing swapId', async () => {
+            // invoke %getSwap on bridge through view contract
+            const swapInititator = accounts.sender.pkh;
+            const operationPromise = getViewsInstance.requestSwap(
+                helpers.tzip7.instance.address, 
+                _cryptoHelpers.randomSecret(), 
+                swapInititator
+            );
+
+            await expect(operationPromise).to.be.eventually.rejected
+                .and.have.property('message', contractErrors.tzip7.swapLockDoesNotExist);
         });
     });
 });

--- a/test/unit/bridge/getSwap.js
+++ b/test/unit/bridge/getSwap.js
@@ -41,7 +41,8 @@ contract('TZIP-7 with bridge', () => {
         
         it('should return the swap lock to the view contract', async () => {
             // invoke %getSwap on bridge through view contract
-            await getViewsInstance.requestSwap(helpers.tzip7.instance.address, swapLockParameters.secretHash);
+            const swapInititator = accounts.sender.pkh;
+            await getViewsInstance.requestSwap(helpers.tzip7.instance.address, swapLockParameters.secretHash, swapInititator);
 
             // read callback swap that was saved into storage
             const storageGetViewsInstance = await getViewsInstance.storage()

--- a/test/unit/bridge/lock.js
+++ b/test/unit/bridge/lock.js
@@ -108,9 +108,9 @@ contract('TZIP-7 with bridge', () => {
             );
             await _taquitoHelpers.setSigner(accounts.sender.sk);
             // time threshold is current time + minimum time constant of 10 minutes
-            // not using 9 minutes for this test, because sandbox network does not update 
-            // network time after initialization (ganache-core)
-            swapLockParameters.releaseTime = getDelayedISOTime(5); 
+            // this test will fail when running many tests at once, because the
+            // sandbox does not update network time after initialization (ganache-core)
+            swapLockParameters.releaseTime = getDelayedISOTime(0); 
             swapLockParameters.secretHash = _cryptoHelpers.randomHash();
         });
 

--- a/test/unit/bridge/lock.js
+++ b/test/unit/bridge/lock.js
@@ -23,7 +23,7 @@ contract('TZIP-7 with bridge', () => {
         
         beforeEach(async () => {
             await before(
-                _tzip7InitialStorage.test.lock, 
+                _tzip7InitialStorage.test.lock(), 
                 accounts,
                 helpers
             );
@@ -53,7 +53,11 @@ contract('TZIP-7 with bridge', () => {
 
             it('should create swap record in contract storage', async () => {
                 // swap entry matches lock parameters
-                const swapFromContract = await helpers.tzip7.getSwap(swapLockParameters.secretHash);
+                const swapId = {
+                    0: swapLockParameters.secretHash,
+                    1: accounts.sender.pkh // swap initiator
+                }; 
+                const swapFromContract = await helpers.tzip7.getSwap(swapId);
                 let swapRecord = swapLockParameters;
                 swapRecord.from = accounts.sender.pkh; // add this for assertion
                 delete swapRecord.secretHash; // remove this for assertion
@@ -73,8 +77,8 @@ contract('TZIP-7 with bridge', () => {
         
         it('should not allow to reuse a secret-hash', async () => {
             // call the token contract at the %lock entrypoint with an already used secretHash from initialStorage
-            swapLockParameters.secretHash = _tzip7InitialStorage.test.lock.bridge.swaps.keys().next().value
-            
+            swapLockParameters.secretHash = _tzip7InitialStorage.test.lock().bridge.swaps.keys().next().value[0]
+
             const operationPromise = helpers.tzip7.lock(swapLockParameters);
             await expect(operationPromise).to.be.eventually.rejected
                 .and.be.instanceOf(TezosOperationError)
@@ -98,7 +102,7 @@ contract('TZIP-7 with bridge', () => {
         
         beforeEach(async () => {
             await before(
-                _tzip7InitialStorage.test.lock, 
+                _tzip7InitialStorage.test.lock(), 
                 accounts,
                 helpers
             );


### PR DESCRIPTION
Based on the finding in TOB-SDAOAS-021, this change prevents DOS attacks on swaps by pairing the swap identifier secret hash with the implicit value of transaction sender. In this way, the new identifier is the Michelson pair (secret hash, swap initiator's address).