### PR TITLE
Restrict ganache-cli network interface binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "wait-for-sandbox": "node ./scripts/sandbox/waitForNetwork.js",
     "sandbox:start": "./scripts/sandbox/start_ganache-cli.sh",
     "fix-ligo-version": "./scripts/fix-ligo-version.sh",
-    "env:start": "npm run tools:start bbbox && npm run sandbox:start",
+    "env:start": "npm run tools:start bbbox && npm run sandbox:start -- --host 0.0.0.0",
     "env:kill": "npm run tools:kill bbbox",
     "env:restart": "npm run tools:restart bbbox",
     "env:clean": "npm run tools:kill bbbox && npm run tools:clean bbbox",

--- a/scripts/sandbox/start_ganache-cli.sh
+++ b/scripts/sandbox/start_ganache-cli.sh
@@ -1,1 +1,1 @@
-./node_modules/ganache-cli/cli.js --flavor tezos --seed alice --accounts 10 --host 0.0.0.0
+./node_modules/ganache-cli/cli.js --flavor tezos --seed alice --accounts 10 "$@"


### PR DESCRIPTION
Restrict ganache-cli network interface binding to only 127.0.0.1, when no other tool like BCD is
used. This is change is based on finding TOB-WXTZ-002.